### PR TITLE
feat: add MCP Registry publishing workflow and manifest

### DIFF
--- a/.github/workflows/release-mcp-registry.yaml
+++ b/.github/workflows/release-mcp-registry.yaml
@@ -1,0 +1,58 @@
+name: Publish to MCP Registry
+
+on:
+  workflow_run:
+    workflows: ["Release"]
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Git tag to publish (e.g., v0.0.51)'
+        required: true
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write  # Required for OIDC authentication
+  contents: read
+
+jobs:
+  publish:
+    name: Publish to MCP Registry
+    runs-on: ubuntu-latest
+    # Only run if the Release workflow succeeded or if manually triggered
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Get version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${{ github.event.workflow_run.head_branch }}"
+          fi
+          # Strip the v prefix
+          echo "version=${TAG#v}" >> $GITHUB_OUTPUT
+
+      - name: Update server.json version
+        run: |
+          jq --arg v "${{ steps.version.outputs.version }}" \
+            '.version = $v | .packages[].version = $v' \
+            server.json > server.json.tmp && mv server.json.tmp server.json
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish server to MCP Registry
+        run: ./mcp-publisher publish

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ This MCP server enables AI assistants (like Claude, Gemini, Cursor, and others) 
 - `python/` – Python package providing a script that downloads the correct platform binary from the GitHub releases page and runs it for distribution through pypi.org.
 - `testdata/` – test fixtures including a mock podman binary for testing.
 - `Makefile` – core build tasks; includes `build/*.mk` for packaging targets.
+- `server.json` – MCP Registry manifest file for publishing to the official registry.
 
 ## Feature development
 
@@ -288,7 +289,7 @@ Key dependencies:
 
 ## Distribution Methods
 
-The server is distributed as a binary executable, an npm package, and a Python package.
+The server is distributed as a binary executable, an npm package, a Python package, and is registered in the official MCP Registry.
 
 - **Native binaries** for Linux, macOS, and Windows are available in the GitHub releases.
 - An **npm** package is available at [npmjs.com](https://www.npmjs.com/package/podman-mcp-server).
@@ -296,6 +297,8 @@ The server is distributed as a binary executable, an npm package, and a Python p
 - A **Python** package is available at [pypi.org](https://pypi.org/project/podman-mcp-server/).
   It provides a script that downloads the correct platform binary from the GitHub releases page and runs it.
   It provides a convenient way to run the server using `uvx` or `python -m podman_mcp_server`.
+- The **MCP Registry** entry is available at [modelcontextprotocol.io](https://modelcontextprotocol.io).
+  The `server.json` manifest file in the repository root defines the server metadata for the registry.
 
 ### NPM Package Structure
 
@@ -325,6 +328,20 @@ make python-publish
 ```
 
 The `GIT_TAG_VERSION` variable (derived from git tags) is used for package versions.
+
+### MCP Registry Publishing
+
+The server is automatically published to the official MCP Registry after each release.
+The `.github/workflows/release-mcp-registry.yaml` workflow:
+- Triggers after the Release workflow completes successfully
+- Can be manually triggered with a tag input (e.g., `v0.0.51`)
+- Updates the version in `server.json` (stripping the `v` prefix from the tag)
+- Uses GitHub OIDC authentication with `mcp-publisher` CLI
+
+The `server.json` manifest includes:
+- Server name: `io.github.manusa/podman-mcp-server`
+- npm and PyPI package definitions with STDIO transport
+- Version placeholder (`0.0.0`) replaced at publish time
 
 ## Available MCP Tools
 

--- a/README.md
+++ b/README.md
@@ -107,3 +107,5 @@ make build
 # Run the Podman MCP server with mcp-inspector
 npx @modelcontextprotocol/inspector@latest $(pwd)/podman-mcp-server
 ```
+
+mcp-name: io.github.manusa/podman-mcp-server

--- a/server.json
+++ b/server.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.manusa/podman-mcp-server",
+  "description": "A Model Context Protocol (MCP) server for container runtimes (Podman and Docker)",
+  "repository": {
+    "url": "https://github.com/manusa/podman-mcp-server",
+    "source": "github"
+  },
+  "version": "0.0.0",
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "podman-mcp-server",
+      "version": "0.0.0",
+      "transport": {
+        "type": "stdio"
+      }
+    },
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "podman-mcp-server",
+      "version": "0.0.0",
+      "runtimeHint": "uvx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Add automated publishing to the official Model Context Protocol registry:
- Create server.json manifest with npm and PyPI package definitions
- Add GitHub Actions workflow triggered after releases
- Add mcp-name metadata to README.md for PyPI package discovery
- Update AGENTS.md with MCP Registry documentation

Closes #71