### PR TITLE
feat(mcp): add HTTP transport mode with Streamable HTTP support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,18 +136,20 @@ uvx podman-mcp-server@latest
 
 ### Transport Modes
 
-The server supports two transport modes:
+The server supports multiple transport modes:
 
-1. **STDIO mode** (default) - communicates via standard input/output
-2. **SSE mode** - Server-Sent Events over HTTP
+1. **STDIO mode** (default) - Communicates via standard input/output
+2. **HTTP mode** (`--port`) - Modern HTTP transport with both Streamable HTTP and SSE endpoints
+3. **SSE-only mode** (`--sse-port`) - Legacy Server-Sent Events transport (deprecated)
 
 ```bash
-# Run with SSE transport on a specific port
-./podman-mcp-server --sse-port 8080
-
-# Run with custom base URL for SSE
-./podman-mcp-server --sse-port 8080 --sse-base-url http://localhost:8080
+# Run with HTTP transport on a specific port (Streamable HTTP at /mcp and SSE at /sse)
+./podman-mcp-server --port 8080
 ```
+
+The HTTP mode uses the official MCP Go SDK's `StreamableHTTPHandler` for stateless HTTP-based communication at the `/mcp` endpoint and `SSEHandler` at the `/sse` endpoint.
+
+**Deprecated flags:** The `--sse-port` and `--sse-base-url` flags are deprecated. Use `--port` instead, which provides both Streamable HTTP and SSE endpoints.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -91,9 +91,27 @@ npx podman-mcp-server@latest --help
 
 ### Configuration Options
 
-| Option       | Description                                                                              |
-|--------------|------------------------------------------------------------------------------------------|
-| `--sse-port` | Starts the MCP server in Server-Sent Event (SSE) mode and listens on the specified port. |
+| Option           | Description                                                                                      |
+|------------------|--------------------------------------------------------------------------------------------------|
+| `--port`, `-p`   | Starts the MCP server in HTTP mode with Streamable HTTP at `/mcp` and SSE at `/sse` endpoints.  |
+| `--sse-port`     | **Deprecated.** Use `--port` instead. Starts the MCP server in SSE-only mode.                   |
+| `--sse-base-url` | **Deprecated.** SSE public base URL to use when sending the endpoint message.                   |
+
+### Transport Modes
+
+The server supports multiple transport modes:
+
+1. **STDIO mode** (default) - Communicates via standard input/output
+2. **HTTP mode** (`--port`) - Modern HTTP transport with both Streamable HTTP and SSE endpoints
+3. **SSE-only mode** (`--sse-port`) - Legacy Server-Sent Events transport (deprecated)
+
+```shell
+# Start HTTP server on port 8080 (Streamable HTTP at /mcp and SSE at /sse)
+podman-mcp-server --port 8080
+
+# Legacy SSE-only server on port 8080 (deprecated, use --port instead)
+podman-mcp-server --sse-port 8080
+```
 
 ## 🧑‍💻 Development <a id="development"></a>
 

--- a/internal/test/mcp.go
+++ b/internal/test/mcp.go
@@ -28,10 +28,10 @@ func (s *McpSuite) SetupTest() {
 	s.podmanBinaryDir = WithPodmanBinary(s.T())
 	s.mcpServer, err = mcpServer.NewServer()
 	s.Require().NoError(err)
-	// Use the go-sdk's SSE handler wrapped in httptest.Server
-	sseHandler := s.mcpServer.ServeSse()
-	s.mcpHttpServer = httptest.NewServer(sseHandler)
-	s.mcpClient, err = client.NewSSEMCPClient(s.mcpHttpServer.URL + "/sse")
+	// Use the go-sdk's Streamable HTTP handler wrapped in httptest.Server
+	streamableHandler := s.mcpServer.ServeStreamableHTTP()
+	s.mcpHttpServer = httptest.NewServer(streamableHandler)
+	s.mcpClient, err = client.NewStreamableHttpClient(s.mcpHttpServer.URL)
 	s.Require().NoError(err)
 	err = s.mcpClient.Start(s.T().Context())
 	s.Require().NoError(err)

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -69,3 +69,10 @@ func (s *Server) ServeSse() *mcp.SSEHandler {
 		return s.server
 	}, nil)
 }
+
+// ServeStreamableHTTP returns an HTTP handler for Streamable HTTP transport.
+func (s *Server) ServeStreamableHTTP() *mcp.StreamableHTTPHandler {
+	return mcp.NewStreamableHTTPHandler(func(_ *http.Request) *mcp.Server {
+		return s.server
+	}, nil)
+}

--- a/pkg/podman-mcp-server/cmd/root.go
+++ b/pkg/podman-mcp-server/cmd/root.go
@@ -31,13 +31,8 @@ Podman Model Context Protocol (MCP) server
   # start STDIO server
   podman-mcp-server
 
-  # start a SSE server on port 8080
-  podman-mcp-server --sse-port 8080
-
-  # start a SSE server on port 8443 with a public HTTPS host of example.com
-  podman-mcp-server --sse-port 8443 --sse-base-url https://example.com:8443
-
-  # TODO: add more examples`,
+  # start HTTP server on port 8080 (Streamable HTTP at /mcp and SSE at /sse)
+  podman-mcp-server --port 8080`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if viper.GetBool("version") {
 			fmt.Println(version.Version)
@@ -61,7 +56,22 @@ Podman Model Context Protocol (MCP) server
 		}
 
 		var httpServer *http.Server
-		if ssePort := viper.GetInt("sse-port"); ssePort > 0 {
+		if port := viper.GetInt("port"); port > 0 {
+			// Modern HTTP mode: serve both Streamable HTTP and SSE endpoints
+			mux := http.NewServeMux()
+			mux.Handle("/mcp", mcpServer.ServeStreamableHTTP())
+			mux.Handle("/sse", mcpServer.ServeSse())
+			httpServer = &http.Server{
+				Addr:    fmt.Sprintf(":%d", port),
+				Handler: mux,
+			}
+			go func() {
+				if err := httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+					panic(err)
+				}
+			}()
+		} else if ssePort := viper.GetInt("sse-port"); ssePort > 0 {
+			// Legacy SSE-only mode for backwards compatibility
 			sseHandler := mcpServer.ServeSse()
 			httpServer = &http.Server{
 				Addr:    fmt.Sprintf(":%d", ssePort),
@@ -86,8 +96,11 @@ Podman Model Context Protocol (MCP) server
 
 func init() {
 	rootCmd.Flags().BoolP("version", "v", false, "Print version information and quit")
-	rootCmd.Flags().IntP("sse-port", "", 0, "Start a SSE server on the specified port")
+	rootCmd.Flags().IntP("port", "p", 0, "Start HTTP server on the specified port (Streamable HTTP at /mcp and SSE at /sse)")
+	rootCmd.Flags().IntP("sse-port", "", 0, "Start a legacy SSE-only server on the specified port")
 	rootCmd.Flags().StringP("sse-base-url", "", "", "SSE public base URL to use when sending the endpoint message (e.g. https://example.com)")
+	_ = rootCmd.Flags().MarkDeprecated("sse-port", "use --port instead")
+	_ = rootCmd.Flags().MarkDeprecated("sse-base-url", "use --port instead")
 	_ = viper.BindPFlags(rootCmd.Flags())
 }
 

--- a/pkg/podman-mcp-server/cmd/root_test.go
+++ b/pkg/podman-mcp-server/cmd/root_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"io"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -25,5 +26,34 @@ func TestVersion(t *testing.T) {
 	if version != "0.0.0\n" {
 		t.Fatalf("Expected version 0.0.0, got %s %v", version, err)
 		return
+	}
+}
+
+func TestHelpContainsPortFlag(t *testing.T) {
+	rootCmd.SetArgs([]string{"--help"})
+	help, err := captureOutput(rootCmd.Execute)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	if !strings.Contains(help, "--port") {
+		t.Fatalf("Expected help to contain --port flag, got %s", help)
+	}
+	if !strings.Contains(help, "Streamable HTTP at /mcp and SSE at /sse") {
+		t.Fatalf("Expected help to contain Streamable HTTP endpoint description, got %s", help)
+	}
+}
+
+func TestHelpHidesDeprecatedFlags(t *testing.T) {
+	rootCmd.SetArgs([]string{"--help"})
+	help, err := captureOutput(rootCmd.Execute)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	// Deprecated flags should be hidden from help output
+	if strings.Contains(help, "--sse-port") {
+		t.Fatalf("Expected help to NOT contain deprecated --sse-port flag, got %s", help)
+	}
+	if strings.Contains(help, "--sse-base-url") {
+		t.Fatalf("Expected help to NOT contain deprecated --sse-base-url flag, got %s", help)
 	}
 }


### PR DESCRIPTION
Add support for HTTP transport mode using the official MCP Go SDK's StreamableHTTPHandler. The new --port flag starts an HTTP server with both Streamable HTTP (/mcp) and SSE (/sse) endpoints.

- Add ServeStreamableHTTP() method to MCP server
- Add --port CLI flag for modern HTTP transport
- Deprecate --sse-port and --sse-base-url flags
- Update test infrastructure to use Streamable HTTP client
- Add CLI help text tests for new flags

Fixes #78