### PR TITLE
feat(test): add mock Podman API server infrastructure

### DIFF
--- a/internal/test/mcp.go
+++ b/internal/test/mcp.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"path"
@@ -70,4 +71,138 @@ func (s *McpSuite) WithPodmanOutput(outputLines ...string) {
 // ListTools returns the list of available MCP tools.
 func (s *McpSuite) ListTools() (*mcp.ListToolsResult, error) {
 	return s.mcpClient.ListTools(s.T().Context(), mcp.ListToolsRequest{})
+}
+
+// MockServerMcpSuite is a test suite that uses a mock Podman API server
+// instead of a fake podman binary. This allows testing with the real
+// podman/docker CLI binary communicating with a mocked backend.
+//
+// Use this suite when you want to:
+// - Test the actual podman/docker CLI behavior
+// - Test complex API responses
+// - Test error scenarios from the API
+//
+// Note: This suite requires a real podman or docker binary to be available.
+// If neither is available, tests using this suite will be skipped.
+type MockServerMcpSuite struct {
+	suite.Suite
+	MockServer    *MockPodmanServer
+	mcpServer     *mcpServer.Server
+	mcpHttpServer *httptest.Server
+	mcpClient     *client.Client
+	cleanupEnv    func()
+}
+
+// SetupTest initializes the mock server, MCP server, and client before each test.
+func (s *MockServerMcpSuite) SetupTest() {
+	// Check if real podman or docker is available
+	s.Require().True(IsPodmanAvailable() || IsDockerAvailable(),
+		"neither podman nor docker CLI is available - install one to run these tests")
+
+	var err error
+
+	// Start mock Podman API server
+	s.MockServer = NewMockPodmanServer()
+
+	// Set CONTAINER_HOST/DOCKER_HOST to point to mock server
+	s.cleanupEnv = WithContainerHost(s.T(), s.MockServer.URL())
+
+	// Create MCP server (it will use the real podman binary which talks to mock server)
+	s.mcpServer, err = mcpServer.NewServer()
+	s.Require().NoError(err)
+
+	// Wrap in httptest.Server with Streamable HTTP handler
+	streamableHandler := s.mcpServer.ServeStreamableHTTP()
+	s.mcpHttpServer = httptest.NewServer(streamableHandler)
+
+	// Create MCP client
+	s.mcpClient, err = client.NewStreamableHttpClient(s.mcpHttpServer.URL)
+	s.Require().NoError(err)
+
+	err = s.mcpClient.Start(s.T().Context())
+	s.Require().NoError(err)
+
+	// Initialize MCP protocol
+	initRequest := mcp.InitializeRequest{}
+	initRequest.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+	initRequest.Params.ClientInfo = mcp.Implementation{Name: "test", Version: "1.33.7"}
+	_, err = s.mcpClient.Initialize(s.T().Context(), initRequest)
+	s.Require().NoError(err)
+}
+
+// TearDownTest cleans up resources after each test.
+func (s *MockServerMcpSuite) TearDownTest() {
+	if s.mcpClient != nil {
+		_ = s.mcpClient.Close()
+	}
+	if s.mcpHttpServer != nil {
+		s.mcpHttpServer.Close()
+	}
+	if s.MockServer != nil {
+		s.MockServer.Close()
+	}
+	if s.cleanupEnv != nil {
+		s.cleanupEnv()
+	}
+}
+
+// CallTool calls an MCP tool by name with the given arguments.
+func (s *MockServerMcpSuite) CallTool(name string, args map[string]interface{}) (*mcp.CallToolResult, error) {
+	callToolRequest := mcp.CallToolRequest{}
+	callToolRequest.Params.Name = name
+	callToolRequest.Params.Arguments = args
+	return s.mcpClient.CallTool(s.T().Context(), callToolRequest)
+}
+
+// ListTools returns the list of available MCP tools.
+func (s *MockServerMcpSuite) ListTools() (*mcp.ListToolsResult, error) {
+	return s.mcpClient.ListTools(s.T().Context(), mcp.ListToolsRequest{})
+}
+
+// WithContainerList sets up the mock server to return a list of containers.
+func (s *MockServerMcpSuite) WithContainerList(containers []ContainerListResponse) {
+	handler := func(w http.ResponseWriter, _ *http.Request) {
+		WriteJSON(w, containers)
+	}
+	s.MockServer.HandleFunc("GET", "/libpod/containers/json", "/containers/json", handler)
+}
+
+// WithContainerInspect sets up the mock server to return container inspect data.
+func (s *MockServerMcpSuite) WithContainerInspect(container ContainerInspectResponse) {
+	handler := func(w http.ResponseWriter, _ *http.Request) {
+		WriteJSON(w, container)
+	}
+	s.MockServer.HandleFunc("GET", "/libpod/containers/{id}/json", "/containers/{id}/json", handler)
+}
+
+// WithImageList sets up the mock server to return a list of images.
+func (s *MockServerMcpSuite) WithImageList(images []ImageListResponse) {
+	handler := func(w http.ResponseWriter, _ *http.Request) {
+		WriteJSON(w, images)
+	}
+	s.MockServer.HandleFunc("GET", "/libpod/images/json", "/images/json", handler)
+}
+
+// WithNetworkList sets up the mock server to return a list of networks.
+func (s *MockServerMcpSuite) WithNetworkList(networks []NetworkListResponse) {
+	handler := func(w http.ResponseWriter, _ *http.Request) {
+		WriteJSON(w, networks)
+	}
+	s.MockServer.HandleFunc("GET", "/libpod/networks/json", "/networks", handler)
+}
+
+// WithVolumeList sets up the mock server to return a list of volumes.
+func (s *MockServerMcpSuite) WithVolumeList(volumes VolumeListResponse) {
+	handler := func(w http.ResponseWriter, _ *http.Request) {
+		WriteJSON(w, volumes)
+	}
+	s.MockServer.HandleFunc("GET", "/libpod/volumes/json", "/volumes", handler)
+}
+
+// WithError sets up the mock server to return an error for a specific endpoint.
+func (s *MockServerMcpSuite) WithError(method, libpodPath, dockerPath string, statusCode int, message string) {
+	handler := func(w http.ResponseWriter, _ *http.Request) {
+		WriteError(w, statusCode, message)
+	}
+	s.MockServer.HandleFunc(method, libpodPath, dockerPath, handler)
 }

--- a/internal/test/mock_server.go
+++ b/internal/test/mock_server.go
@@ -1,0 +1,324 @@
+package test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+)
+
+// MockPodmanServer is a mock HTTP server that simulates the Podman/Docker API.
+// It supports both Libpod API (/libpod/...) and Docker-compatible API (/v1.x/... and /...).
+type MockPodmanServer struct {
+	server   *httptest.Server
+	handlers map[string]http.HandlerFunc
+	requests []CapturedRequest
+	mu       sync.RWMutex
+}
+
+// CapturedRequest represents a captured HTTP request for test assertions.
+type CapturedRequest struct {
+	Method string
+	Path   string
+	Query  string
+	Body   []byte
+}
+
+// NewMockPodmanServer creates a new mock Podman API server.
+func NewMockPodmanServer() *MockPodmanServer {
+	m := &MockPodmanServer{
+		handlers: make(map[string]http.HandlerFunc),
+		requests: make([]CapturedRequest, 0),
+	}
+	m.server = httptest.NewServer(http.HandlerFunc(m.ServeHTTP))
+	m.registerBaseEndpoints()
+	return m
+}
+
+// ServeHTTP handles incoming HTTP requests by routing to registered handlers.
+func (m *MockPodmanServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Capture the request
+	m.captureRequest(r)
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	path := r.URL.Path
+
+	// Try exact match first
+	if handler, ok := m.handlers[r.Method+" "+path]; ok {
+		handler(w, r)
+		return
+	}
+
+	// Try pattern matching for paths with IDs (e.g., /containers/{id}/json)
+	for pattern, handler := range m.handlers {
+		if matchPath(pattern, r.Method+" "+path) {
+			handler(w, r)
+			return
+		}
+	}
+
+	// Default 404 response
+	http.NotFound(w, r)
+}
+
+// captureRequest captures an incoming request for later inspection.
+func (m *MockPodmanServer) captureRequest(r *http.Request) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	captured := CapturedRequest{
+		Method: r.Method,
+		Path:   r.URL.Path,
+		Query:  r.URL.RawQuery,
+	}
+	// Note: We don't read the body here to avoid consuming it before handlers
+	m.requests = append(m.requests, captured)
+}
+
+// Requests returns all captured requests.
+func (m *MockPodmanServer) Requests() []CapturedRequest {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return append([]CapturedRequest{}, m.requests...)
+}
+
+// LastRequest returns the most recent captured request, or nil if none.
+func (m *MockPodmanServer) LastRequest() *CapturedRequest {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if len(m.requests) == 0 {
+		return nil
+	}
+	req := m.requests[len(m.requests)-1]
+	return &req
+}
+
+// ClearRequests clears all captured requests.
+func (m *MockPodmanServer) ClearRequests() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.requests = make([]CapturedRequest, 0)
+}
+
+// HasRequest checks if a request with the given method and path pattern was made.
+func (m *MockPodmanServer) HasRequest(method, pathPattern string) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, req := range m.requests {
+		if req.Method == method && matchPathSimple(pathPattern, req.Path) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchPathSimple checks if a path matches a pattern (supports {placeholder} syntax).
+func matchPathSimple(pattern, path string) bool {
+	patternParts := strings.Split(pattern, "/")
+	pathParts := strings.Split(path, "/")
+
+	if len(patternParts) != len(pathParts) {
+		return false
+	}
+
+	for i, pp := range patternParts {
+		if strings.HasPrefix(pp, "{") && strings.HasSuffix(pp, "}") {
+			continue
+		}
+		if pp != pathParts[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// matchPath checks if a request path matches a pattern with placeholders.
+// Pattern example: "GET /libpod/containers/{id}/json"
+// Path example: "GET /libpod/containers/abc123/json"
+func matchPath(pattern, path string) bool {
+	patternParts := strings.Split(pattern, "/")
+	pathParts := strings.Split(path, "/")
+
+	if len(patternParts) != len(pathParts) {
+		return false
+	}
+
+	for i, pp := range patternParts {
+		if strings.HasPrefix(pp, "{") && strings.HasSuffix(pp, "}") {
+			// Placeholder matches any value
+			continue
+		}
+		if pp != pathParts[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// URL returns the base URL of the mock server.
+func (m *MockPodmanServer) URL() string {
+	return m.server.URL
+}
+
+// Close shuts down the mock server.
+func (m *MockPodmanServer) Close() {
+	if m.server != nil {
+		m.server.Close()
+	}
+}
+
+// Handle registers a handler for a specific HTTP method and path.
+// The path can include placeholders like {id} for dynamic segments.
+func (m *MockPodmanServer) Handle(method, path string, handler http.HandlerFunc) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.handlers[method+" "+path] = handler
+}
+
+// HandleFunc is a convenience method that registers a handler for both
+// Libpod and Docker-compatible API paths.
+func (m *MockPodmanServer) HandleFunc(method, libpodPath, dockerPath string, handler http.HandlerFunc) {
+	m.Handle(method, libpodPath, handler)
+	if dockerPath != "" {
+		m.Handle(method, dockerPath, handler)
+		// Also register with version prefix for Docker API
+		m.Handle(method, "/v1.40"+dockerPath, handler)
+		m.Handle(method, "/v1.41"+dockerPath, handler)
+	}
+}
+
+// ResetHandlers clears all registered handlers and re-registers base endpoints.
+// Also clears captured requests.
+func (m *MockPodmanServer) ResetHandlers() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.handlers = make(map[string]http.HandlerFunc)
+	m.requests = make([]CapturedRequest, 0)
+	m.registerBaseEndpointsLocked()
+}
+
+// registerBaseEndpoints registers the base API endpoints required for podman/docker CLI.
+func (m *MockPodmanServer) registerBaseEndpoints() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.registerBaseEndpointsLocked()
+}
+
+// registerBaseEndpointsLocked registers base endpoints (must hold lock).
+func (m *MockPodmanServer) registerBaseEndpointsLocked() {
+	// Health check endpoint
+	pingHandler := func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	}
+	m.handlers["GET /_ping"] = pingHandler
+	m.handlers["HEAD /_ping"] = pingHandler
+	m.handlers["GET /libpod/_ping"] = pingHandler
+
+	// Version endpoint
+	versionHandler := func(w http.ResponseWriter, _ *http.Request) {
+		WriteJSON(w, VersionResponse{
+			APIVersion:    "1.40",
+			Arch:          "amd64",
+			Built:         1234567890,
+			BuildTime:     "2024-01-01T00:00:00Z",
+			Components:    []ComponentVersion{},
+			Experimental:  false,
+			GitCommit:     "mock",
+			GoVersion:     "go1.21",
+			KernelVersion: "5.15.0",
+			MinAPIVersion: "1.24",
+			Os:            "linux",
+			Version:       "4.0.0",
+		})
+	}
+	m.handlers["GET /version"] = versionHandler
+	m.handlers["GET /libpod/version"] = versionHandler
+	m.handlers["GET /v1.40/version"] = versionHandler
+	m.handlers["GET /v1.41/version"] = versionHandler
+
+	// Info endpoint
+	infoHandler := func(w http.ResponseWriter, _ *http.Request) {
+		WriteJSON(w, InfoResponse{
+			Host: HostInfo{
+				Arch:           "amd64",
+				BuildahVersion: "1.30.0",
+				Conmon: ConmonInfo{
+					Package: "conmon-2.1.0",
+					Path:    "/usr/bin/conmon",
+					Version: "conmon version 2.1.0",
+				},
+				Distribution: DistributionInfo{
+					Distribution: "fedora",
+					Version:      "39",
+				},
+				Hostname:    "mock-host",
+				Kernel:      "5.15.0",
+				MemFree:     1024 * 1024 * 1024,
+				MemTotal:    8 * 1024 * 1024 * 1024,
+				OS:          "linux",
+				Rootless:    true,
+				Uptime:      "1h 0m 0s",
+				CPUs:        4,
+				EventLogger: "journald",
+				SecurityInfo: SecurityInfo{
+					AppArmorEnabled:    false,
+					SELinuxEnabled:     false,
+					SeccompEnabled:     true,
+					SeccompProfilePath: "/usr/share/containers/seccomp.json",
+					Rootless:           true,
+				},
+			},
+			Store: StoreInfo{
+				GraphDriverName: "overlay",
+				GraphRoot:       "/home/user/.local/share/containers/storage",
+				RunRoot:         "/run/user/1000/containers",
+				ImageStore: ImageStoreInfo{
+					Number: 10,
+				},
+				ContainerStore: ContainerStoreInfo{
+					Number:  5,
+					Running: 2,
+					Paused:  0,
+					Stopped: 3,
+				},
+			},
+			Version: VersionInfo{
+				APIVersion: "1.40",
+				Built:      1234567890,
+				BuiltTime:  "2024-01-01T00:00:00Z",
+				GitCommit:  "mock",
+				GoVersion:  "go1.21",
+				OsArch:     "linux/amd64",
+				Version:    "4.0.0",
+			},
+		})
+	}
+	m.handlers["GET /info"] = infoHandler
+	m.handlers["GET /libpod/info"] = infoHandler
+	m.handlers["GET /v1.40/info"] = infoHandler
+	m.handlers["GET /v1.41/info"] = infoHandler
+}
+
+// WriteJSON writes a JSON response to the http.ResponseWriter.
+func WriteJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+// WriteError writes an error response in the format expected by podman/docker CLI.
+func WriteError(w http.ResponseWriter, statusCode int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	_ = json.NewEncoder(w).Encode(ErrorResponse{
+		Cause:    message,
+		Message:  message,
+		Response: statusCode,
+	})
+}

--- a/internal/test/mock_server_test.go
+++ b/internal/test/mock_server_test.go
@@ -1,0 +1,225 @@
+package test_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/manusa/podman-mcp-server/internal/test"
+)
+
+type MockPodmanServerSuite struct {
+	suite.Suite
+	server *test.MockPodmanServer
+}
+
+func TestMockPodmanServer(t *testing.T) {
+	suite.Run(t, new(MockPodmanServerSuite))
+}
+
+func (s *MockPodmanServerSuite) SetupTest() {
+	s.server = test.NewMockPodmanServer()
+}
+
+func (s *MockPodmanServerSuite) TearDownTest() {
+	if s.server != nil {
+		s.server.Close()
+	}
+}
+
+func (s *MockPodmanServerSuite) TestStartsAndProvidesURL() {
+	s.NotEmpty(s.server.URL())
+	s.Contains(s.server.URL(), "http://")
+}
+
+func (s *MockPodmanServerSuite) TestRespondsToPingEndpoint() {
+	resp, err := http.Get(s.server.URL() + "/_ping")
+	s.Require().NoError(err)
+	defer func() { _ = resp.Body.Close() }()
+
+	s.Equal(http.StatusOK, resp.StatusCode)
+}
+
+func (s *MockPodmanServerSuite) TestRespondsToVersionEndpoint() {
+	resp, err := http.Get(s.server.URL() + "/version")
+	s.Require().NoError(err)
+	defer func() { _ = resp.Body.Close() }()
+
+	s.Equal(http.StatusOK, resp.StatusCode)
+	s.Equal("application/json", resp.Header.Get("Content-Type"))
+}
+
+func (s *MockPodmanServerSuite) TestRespondsToLibpodVersionEndpoint() {
+	resp, err := http.Get(s.server.URL() + "/libpod/version")
+	s.Require().NoError(err)
+	defer func() { _ = resp.Body.Close() }()
+
+	s.Equal(http.StatusOK, resp.StatusCode)
+}
+
+func (s *MockPodmanServerSuite) TestRespondsToVersionedDockerAPI() {
+	resp, err := http.Get(s.server.URL() + "/v1.40/version")
+	s.Require().NoError(err)
+	defer func() { _ = resp.Body.Close() }()
+
+	s.Equal(http.StatusOK, resp.StatusCode)
+}
+
+func (s *MockPodmanServerSuite) TestRespondsToInfoEndpoint() {
+	resp, err := http.Get(s.server.URL() + "/info")
+	s.Require().NoError(err)
+	defer func() { _ = resp.Body.Close() }()
+
+	s.Equal(http.StatusOK, resp.StatusCode)
+}
+
+func (s *MockPodmanServerSuite) TestReturns404ForUnknownEndpoints() {
+	resp, err := http.Get(s.server.URL() + "/unknown/endpoint")
+	s.Require().NoError(err)
+	defer func() { _ = resp.Body.Close() }()
+
+	s.Equal(http.StatusNotFound, resp.StatusCode)
+}
+
+func (s *MockPodmanServerSuite) TestCapturesRequests() {
+	_, err := http.Get(s.server.URL() + "/_ping")
+	s.Require().NoError(err)
+
+	_, err = http.Get(s.server.URL() + "/version")
+	s.Require().NoError(err)
+
+	requests := s.server.Requests()
+	s.GreaterOrEqual(len(requests), 2)
+
+	s.True(s.server.HasRequest("GET", "/_ping"))
+	s.True(s.server.HasRequest("GET", "/version"))
+}
+
+func (s *MockPodmanServerSuite) TestClearsRequests() {
+	_, _ = http.Get(s.server.URL() + "/_ping")
+	s.NotEmpty(s.server.Requests())
+
+	s.server.ClearRequests()
+	s.Empty(s.server.Requests())
+}
+
+func (s *MockPodmanServerSuite) TestCustomHandlerRegistration() {
+	s.server.Handle("GET", "/custom/endpoint", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte("custom response"))
+	})
+
+	resp, err := http.Get(s.server.URL() + "/custom/endpoint")
+	s.Require().NoError(err)
+	defer func() { _ = resp.Body.Close() }()
+
+	s.Equal(http.StatusCreated, resp.StatusCode)
+}
+
+func (s *MockPodmanServerSuite) TestDualAPIHandlerRegistration() {
+	s.server.HandleFunc("GET", "/libpod/containers/json", "/containers/json", func(w http.ResponseWriter, _ *http.Request) {
+		test.WriteJSON(w, []test.ContainerListResponse{
+			{ID: "abc123", Names: []string{"test-container"}, State: "running"},
+		})
+	})
+
+	s.Run("libpod path", func() {
+		resp, err := http.Get(s.server.URL() + "/libpod/containers/json")
+		s.Require().NoError(err)
+		defer func() { _ = resp.Body.Close() }()
+		s.Equal(http.StatusOK, resp.StatusCode)
+	})
+
+	s.Run("docker-compatible path", func() {
+		resp, err := http.Get(s.server.URL() + "/containers/json")
+		s.Require().NoError(err)
+		defer func() { _ = resp.Body.Close() }()
+		s.Equal(http.StatusOK, resp.StatusCode)
+	})
+
+	s.Run("versioned docker path", func() {
+		resp, err := http.Get(s.server.URL() + "/v1.40/containers/json")
+		s.Require().NoError(err)
+		defer func() { _ = resp.Body.Close() }()
+		s.Equal(http.StatusOK, resp.StatusCode)
+	})
+}
+
+func (s *MockPodmanServerSuite) TestPathPatternMatchingWithPlaceholders() {
+	s.server.Handle("GET", "/libpod/containers/{id}/json", func(w http.ResponseWriter, _ *http.Request) {
+		test.WriteJSON(w, test.ContainerInspectResponse{
+			ID:   "matched-container",
+			Name: "/test",
+		})
+	})
+
+	resp, err := http.Get(s.server.URL() + "/libpod/containers/abc123/json")
+	s.Require().NoError(err)
+	defer func() { _ = resp.Body.Close() }()
+
+	s.Equal(http.StatusOK, resp.StatusCode)
+}
+
+func (s *MockPodmanServerSuite) TestErrorResponseHelper() {
+	s.server.Handle("GET", "/error/endpoint", func(w http.ResponseWriter, _ *http.Request) {
+		test.WriteError(w, http.StatusNotFound, "container not found")
+	})
+
+	resp, err := http.Get(s.server.URL() + "/error/endpoint")
+	s.Require().NoError(err)
+	defer func() { _ = resp.Body.Close() }()
+
+	s.Equal(http.StatusNotFound, resp.StatusCode)
+}
+
+func (s *MockPodmanServerSuite) TestResetHandlers() {
+	s.server.Handle("GET", "/custom", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	s.Run("custom endpoint works before reset", func() {
+		resp, err := http.Get(s.server.URL() + "/custom")
+		s.Require().NoError(err)
+		defer func() { _ = resp.Body.Close() }()
+		s.Equal(http.StatusOK, resp.StatusCode)
+	})
+
+	s.server.ResetHandlers()
+
+	s.Run("custom endpoint returns 404 after reset", func() {
+		resp, err := http.Get(s.server.URL() + "/custom")
+		s.Require().NoError(err)
+		defer func() { _ = resp.Body.Close() }()
+		s.Equal(http.StatusNotFound, resp.StatusCode)
+	})
+
+	s.Run("base endpoints still work after reset", func() {
+		resp, err := http.Get(s.server.URL() + "/_ping")
+		s.Require().NoError(err)
+		defer func() { _ = resp.Body.Close() }()
+		s.Equal(http.StatusOK, resp.StatusCode)
+	})
+}
+
+type BinaryDetectionSuite struct {
+	suite.Suite
+}
+
+func TestBinaryDetection(t *testing.T) {
+	suite.Run(t, new(BinaryDetectionSuite))
+}
+
+func (s *BinaryDetectionSuite) TestIsPodmanAvailable() {
+	// This test just verifies the function doesn't panic
+	// The result depends on whether podman is installed
+	available := test.IsPodmanAvailable()
+	s.T().Logf("IsPodmanAvailable: %v", available)
+}
+
+func (s *BinaryDetectionSuite) TestIsDockerAvailable() {
+	// This test just verifies the function doesn't panic
+	// The result depends on whether docker is installed
+	available := test.IsDockerAvailable()
+	s.T().Logf("IsDockerAvailable: %v", available)
+}

--- a/internal/test/podman.go
+++ b/internal/test/podman.go
@@ -2,10 +2,12 @@ package test
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 	"path"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -36,4 +38,69 @@ func WithPodmanBinary(t *testing.T) string {
 func testdataPath() string {
 	// Navigate from internal/test to project root, then to testdata
 	return path.Join("..", "..", "testdata")
+}
+
+// IsPodmanAvailable checks if the real podman binary is available in PATH.
+func IsPodmanAvailable() bool {
+	filePath, err := exec.LookPath("podman")
+	if err != nil {
+		return false
+	}
+	// Verify it's actually podman and not our fake binary
+	output, err := exec.Command(filePath, "version", "--format", "{{.Client.Version}}").CombinedOutput()
+	if err != nil {
+		return false
+	}
+	// Real podman outputs a version number like "4.0.0"
+	version := strings.TrimSpace(string(output))
+	return len(version) > 0 && version[0] >= '0' && version[0] <= '9'
+}
+
+// IsDockerAvailable checks if the docker binary is available in PATH.
+func IsDockerAvailable() bool {
+	filePath, err := exec.LookPath("docker")
+	if err != nil {
+		return false
+	}
+	output, err := exec.Command(filePath, "version", "--format", "{{.Client.Version}}").CombinedOutput()
+	if err != nil {
+		return false
+	}
+	version := strings.TrimSpace(string(output))
+	return len(version) > 0 && version[0] >= '0' && version[0] <= '9'
+}
+
+// WithContainerHost sets the CONTAINER_HOST environment variable to point to the mock server.
+// This redirects podman CLI commands to the mock server.
+// Returns a cleanup function that restores the original environment.
+func WithContainerHost(t *testing.T, serverURL string) func() {
+	originalContainerHost := os.Getenv("CONTAINER_HOST")
+	originalDockerHost := os.Getenv("DOCKER_HOST")
+
+	// Convert http://localhost:PORT to tcp://localhost:PORT for podman
+	u, err := url.Parse(serverURL)
+	if err != nil {
+		t.Fatalf("failed to parse server URL: %v", err)
+	}
+	tcpURL := "tcp://" + u.Host
+
+	if err := os.Setenv("CONTAINER_HOST", tcpURL); err != nil {
+		t.Fatalf("failed to set CONTAINER_HOST: %v", err)
+	}
+	if err := os.Setenv("DOCKER_HOST", tcpURL); err != nil {
+		t.Fatalf("failed to set DOCKER_HOST: %v", err)
+	}
+
+	return func() {
+		if originalContainerHost != "" {
+			_ = os.Setenv("CONTAINER_HOST", originalContainerHost)
+		} else {
+			_ = os.Unsetenv("CONTAINER_HOST")
+		}
+		if originalDockerHost != "" {
+			_ = os.Setenv("DOCKER_HOST", originalDockerHost)
+		} else {
+			_ = os.Unsetenv("DOCKER_HOST")
+		}
+	}
 }

--- a/internal/test/types.go
+++ b/internal/test/types.go
@@ -1,0 +1,498 @@
+package test
+
+// Response types for mock Podman/Docker API server.
+// These types are designed to be compatible with both Libpod and Docker APIs.
+
+// ErrorResponse represents an API error response.
+type ErrorResponse struct {
+	Cause    string `json:"cause,omitempty"`
+	Message  string `json:"message"`
+	Response int    `json:"response"`
+}
+
+// VersionResponse represents the response from /version endpoint.
+type VersionResponse struct {
+	APIVersion    string             `json:"ApiVersion"`
+	Arch          string             `json:"Arch"`
+	Built         int64              `json:"Built,omitempty"`
+	BuildTime     string             `json:"BuildTime,omitempty"`
+	Components    []ComponentVersion `json:"Components,omitempty"`
+	Experimental  bool               `json:"Experimental,omitempty"`
+	GitCommit     string             `json:"GitCommit"`
+	GoVersion     string             `json:"GoVersion"`
+	KernelVersion string             `json:"KernelVersion,omitempty"`
+	MinAPIVersion string             `json:"MinAPIVersion,omitempty"`
+	Os            string             `json:"Os"`
+	Version       string             `json:"Version"`
+}
+
+// ComponentVersion represents a component in the version response.
+type ComponentVersion struct {
+	Details map[string]string `json:"Details,omitempty"`
+	Name    string            `json:"Name"`
+	Version string            `json:"Version"`
+}
+
+// InfoResponse represents the response from /info endpoint.
+type InfoResponse struct {
+	Host    HostInfo    `json:"host"`
+	Store   StoreInfo   `json:"store"`
+	Version VersionInfo `json:"version"`
+}
+
+// HostInfo contains host system information.
+type HostInfo struct {
+	Arch           string           `json:"arch"`
+	BuildahVersion string           `json:"buildahVersion"`
+	Conmon         ConmonInfo       `json:"conmon"`
+	Distribution   DistributionInfo `json:"distribution"`
+	Hostname       string           `json:"hostname"`
+	Kernel         string           `json:"kernel"`
+	MemFree        int64            `json:"memFree"`
+	MemTotal       int64            `json:"memTotal"`
+	OS             string           `json:"os"`
+	Rootless       bool             `json:"rootless"`
+	Uptime         string           `json:"uptime"`
+	CPUs           int              `json:"cpus"`
+	EventLogger    string           `json:"eventLogger"`
+	SecurityInfo   SecurityInfo     `json:"security"`
+}
+
+// ConmonInfo contains conmon information.
+type ConmonInfo struct {
+	Package string `json:"package"`
+	Path    string `json:"path"`
+	Version string `json:"version"`
+}
+
+// DistributionInfo contains OS distribution information.
+type DistributionInfo struct {
+	Distribution string `json:"distribution"`
+	Version      string `json:"version"`
+}
+
+// SecurityInfo contains security-related information.
+type SecurityInfo struct {
+	AppArmorEnabled    bool   `json:"apparmorEnabled"`
+	SELinuxEnabled     bool   `json:"selinuxEnabled"`
+	SeccompEnabled     bool   `json:"seccompEnabled"`
+	SeccompProfilePath string `json:"seccompProfilePath"`
+	Rootless           bool   `json:"rootless"`
+}
+
+// StoreInfo contains storage information.
+type StoreInfo struct {
+	GraphDriverName string             `json:"graphDriverName"`
+	GraphRoot       string             `json:"graphRoot"`
+	RunRoot         string             `json:"runRoot"`
+	ImageStore      ImageStoreInfo     `json:"imageStore"`
+	ContainerStore  ContainerStoreInfo `json:"containerStore"`
+}
+
+// ImageStoreInfo contains image store statistics.
+type ImageStoreInfo struct {
+	Number int `json:"number"`
+}
+
+// ContainerStoreInfo contains container store statistics.
+type ContainerStoreInfo struct {
+	Number  int `json:"number"`
+	Running int `json:"running"`
+	Paused  int `json:"paused"`
+	Stopped int `json:"stopped"`
+}
+
+// VersionInfo contains version information for the info endpoint.
+type VersionInfo struct {
+	APIVersion string `json:"APIVersion"`
+	Built      int64  `json:"Built"`
+	BuiltTime  string `json:"BuiltTime"`
+	GitCommit  string `json:"GitCommit"`
+	GoVersion  string `json:"GoVersion"`
+	OsArch     string `json:"OsArch"`
+	Version    string `json:"Version"`
+}
+
+// ContainerListResponse represents a container in the list response.
+// Compatible with both Libpod and Docker APIs.
+type ContainerListResponse struct {
+	AutoRemove bool              `json:"AutoRemove,omitempty"`
+	Command    []string          `json:"Command,omitempty"`
+	Created    int64             `json:"Created"`
+	CreatedAt  string            `json:"CreatedAt,omitempty"`
+	ExitCode   int               `json:"ExitCode,omitempty"`
+	Exited     bool              `json:"Exited,omitempty"`
+	ExitedAt   int64             `json:"ExitedAt,omitempty"`
+	ID         string            `json:"Id"`
+	Image      string            `json:"Image"`
+	ImageID    string            `json:"ImageID,omitempty"`
+	Labels     map[string]string `json:"Labels,omitempty"`
+	Mounts     []string          `json:"Mounts,omitempty"`
+	Names      []string          `json:"Names"`
+	Namespaces struct{}          `json:"Namespaces,omitempty"`
+	Networks   []string          `json:"Networks,omitempty"`
+	Pid        int               `json:"Pid,omitempty"`
+	Pod        string            `json:"Pod,omitempty"`
+	PodName    string            `json:"PodName,omitempty"`
+	Ports      []PortMapping     `json:"Ports,omitempty"`
+	Size       *ContainerSize    `json:"Size,omitempty"`
+	StartedAt  int64             `json:"StartedAt,omitempty"`
+	State      string            `json:"State"`
+	Status     string            `json:"Status,omitempty"`
+}
+
+// PortMapping represents a port mapping for a container.
+type PortMapping struct {
+	ContainerPort int    `json:"container_port,omitempty"`
+	HostIP        string `json:"host_ip,omitempty"`
+	HostPort      int    `json:"host_port,omitempty"`
+	Protocol      string `json:"protocol,omitempty"`
+	// Docker-compatible fields
+	IP          string `json:"IP,omitempty"`
+	PrivatePort int    `json:"PrivatePort,omitempty"`
+	PublicPort  int    `json:"PublicPort,omitempty"`
+	Type        string `json:"Type,omitempty"`
+}
+
+// ContainerSize represents the size of a container.
+type ContainerSize struct {
+	RootFsSize int64 `json:"rootFsSize"`
+	RwSize     int64 `json:"rwSize"`
+}
+
+// ContainerInspectResponse represents the detailed container information.
+// Compatible with both Libpod and Docker APIs.
+type ContainerInspectResponse struct {
+	AppArmorProfile string           `json:"AppArmorProfile,omitempty"`
+	Args            []string         `json:"Args,omitempty"`
+	Config          *ContainerConfig `json:"Config,omitempty"`
+	Created         string           `json:"Created"`
+	Driver          string           `json:"Driver,omitempty"`
+	HostConfig      *HostConfig      `json:"HostConfig,omitempty"`
+	HostnamePath    string           `json:"HostnamePath,omitempty"`
+	HostsPath       string           `json:"HostsPath,omitempty"`
+	ID              string           `json:"Id"`
+	Image           string           `json:"Image"`
+	ImageName       string           `json:"ImageName,omitempty"`
+	LogPath         string           `json:"LogPath,omitempty"`
+	MountLabel      string           `json:"MountLabel,omitempty"`
+	Mounts          []MountPoint     `json:"Mounts,omitempty"`
+	Name            string           `json:"Name"`
+	Namespace       string           `json:"Namespace,omitempty"`
+	NetworkSettings *NetworkSettings `json:"NetworkSettings,omitempty"`
+	Path            string           `json:"Path,omitempty"`
+	Platform        string           `json:"Platform,omitempty"`
+	ProcessLabel    string           `json:"ProcessLabel,omitempty"`
+	ResolvConfPath  string           `json:"ResolvConfPath,omitempty"`
+	RestartCount    int              `json:"RestartCount,omitempty"`
+	Rootfs          string           `json:"Rootfs,omitempty"`
+	State           *ContainerState  `json:"State,omitempty"`
+	StaticDir       string           `json:"StaticDir,omitempty"`
+}
+
+// ContainerConfig represents container configuration.
+type ContainerConfig struct {
+	AttachStderr bool                `json:"AttachStderr,omitempty"`
+	AttachStdin  bool                `json:"AttachStdin,omitempty"`
+	AttachStdout bool                `json:"AttachStdout,omitempty"`
+	Cmd          []string            `json:"Cmd,omitempty"`
+	Domainname   string              `json:"Domainname,omitempty"`
+	Entrypoint   []string            `json:"Entrypoint,omitempty"`
+	Env          []string            `json:"Env,omitempty"`
+	ExposedPorts map[string]struct{} `json:"ExposedPorts,omitempty"`
+	Hostname     string              `json:"Hostname,omitempty"`
+	Image        string              `json:"Image,omitempty"`
+	Labels       map[string]string   `json:"Labels,omitempty"`
+	OnBuild      []string            `json:"OnBuild,omitempty"`
+	OpenStdin    bool                `json:"OpenStdin,omitempty"`
+	StdinOnce    bool                `json:"StdinOnce,omitempty"`
+	StopSignal   string              `json:"StopSignal,omitempty"`
+	StopTimeout  *int                `json:"StopTimeout,omitempty"`
+	Tty          bool                `json:"Tty,omitempty"`
+	User         string              `json:"User,omitempty"`
+	Volumes      map[string]struct{} `json:"Volumes,omitempty"`
+	WorkingDir   string              `json:"WorkingDir,omitempty"`
+}
+
+// HostConfig represents container host configuration.
+type HostConfig struct {
+	AutoRemove      bool                     `json:"AutoRemove,omitempty"`
+	Binds           []string                 `json:"Binds,omitempty"`
+	CapAdd          []string                 `json:"CapAdd,omitempty"`
+	CapDrop         []string                 `json:"CapDrop,omitempty"`
+	DNS             []string                 `json:"Dns,omitempty"`
+	DNSOptions      []string                 `json:"DnsOptions,omitempty"`
+	DNSSearch       []string                 `json:"DnsSearch,omitempty"`
+	ExtraHosts      []string                 `json:"ExtraHosts,omitempty"`
+	NetworkMode     string                   `json:"NetworkMode,omitempty"`
+	PortBindings    map[string][]PortBinding `json:"PortBindings,omitempty"`
+	Privileged      bool                     `json:"Privileged,omitempty"`
+	PublishAllPorts bool                     `json:"PublishAllPorts,omitempty"`
+	ReadonlyRootfs  bool                     `json:"ReadonlyRootfs,omitempty"`
+	RestartPolicy   *RestartPolicy           `json:"RestartPolicy,omitempty"`
+	SecurityOpt     []string                 `json:"SecurityOpt,omitempty"`
+}
+
+// PortBinding represents a port binding configuration.
+type PortBinding struct {
+	HostIP   string `json:"HostIp,omitempty"`
+	HostPort string `json:"HostPort,omitempty"`
+}
+
+// RestartPolicy represents a container restart policy.
+type RestartPolicy struct {
+	MaximumRetryCount int    `json:"MaximumRetryCount,omitempty"`
+	Name              string `json:"Name,omitempty"`
+}
+
+// MountPoint represents a mount point.
+type MountPoint struct {
+	Destination string `json:"Destination,omitempty"`
+	Driver      string `json:"Driver,omitempty"`
+	Mode        string `json:"Mode,omitempty"`
+	Name        string `json:"Name,omitempty"`
+	Propagation string `json:"Propagation,omitempty"`
+	RW          bool   `json:"RW,omitempty"`
+	Source      string `json:"Source,omitempty"`
+	Type        string `json:"Type,omitempty"`
+}
+
+// NetworkSettings represents container network settings.
+type NetworkSettings struct {
+	Bridge                 string                    `json:"Bridge,omitempty"`
+	EndpointID             string                    `json:"EndpointID,omitempty"`
+	Gateway                string                    `json:"Gateway,omitempty"`
+	GlobalIPv6Address      string                    `json:"GlobalIPv6Address,omitempty"`
+	GlobalIPv6PrefixLen    int                       `json:"GlobalIPv6PrefixLen,omitempty"`
+	HairpinMode            bool                      `json:"HairpinMode,omitempty"`
+	IPAddress              string                    `json:"IPAddress,omitempty"`
+	IPPrefixLen            int                       `json:"IPPrefixLen,omitempty"`
+	IPv6Gateway            string                    `json:"IPv6Gateway,omitempty"`
+	LinkLocalIPv6Address   string                    `json:"LinkLocalIPv6Address,omitempty"`
+	LinkLocalIPv6PrefixLen int                       `json:"LinkLocalIPv6PrefixLen,omitempty"`
+	MacAddress             string                    `json:"MacAddress,omitempty"`
+	Networks               map[string]*NetworkDetail `json:"Networks,omitempty"`
+	Ports                  map[string][]PortBinding  `json:"Ports,omitempty"`
+	SandboxID              string                    `json:"SandboxID,omitempty"`
+	SandboxKey             string                    `json:"SandboxKey,omitempty"`
+}
+
+// NetworkDetail represents network details for a container.
+type NetworkDetail struct {
+	Aliases             []string          `json:"Aliases,omitempty"`
+	DriverOpts          map[string]string `json:"DriverOpts,omitempty"`
+	EndpointID          string            `json:"EndpointID,omitempty"`
+	Gateway             string            `json:"Gateway,omitempty"`
+	GlobalIPv6Address   string            `json:"GlobalIPv6Address,omitempty"`
+	GlobalIPv6PrefixLen int               `json:"GlobalIPv6PrefixLen,omitempty"`
+	IPAMConfig          *IPAMConfig       `json:"IPAMConfig,omitempty"`
+	IPAddress           string            `json:"IPAddress,omitempty"`
+	IPPrefixLen         int               `json:"IPPrefixLen,omitempty"`
+	IPv6Gateway         string            `json:"IPv6Gateway,omitempty"`
+	Links               []string          `json:"Links,omitempty"`
+	MacAddress          string            `json:"MacAddress,omitempty"`
+	NetworkID           string            `json:"NetworkID,omitempty"`
+}
+
+// IPAMConfig represents IPAM configuration.
+type IPAMConfig struct {
+	IPv4Address  string   `json:"IPv4Address,omitempty"`
+	IPv6Address  string   `json:"IPv6Address,omitempty"`
+	LinkLocalIPs []string `json:"LinkLocalIPs,omitempty"`
+}
+
+// ContainerState represents the state of a container.
+type ContainerState struct {
+	Dead       bool         `json:"Dead,omitempty"`
+	Error      string       `json:"Error,omitempty"`
+	ExitCode   int          `json:"ExitCode,omitempty"`
+	FinishedAt string       `json:"FinishedAt,omitempty"`
+	Health     *HealthState `json:"Health,omitempty"`
+	OOMKilled  bool         `json:"OOMKilled,omitempty"`
+	Paused     bool         `json:"Paused,omitempty"`
+	Pid        int          `json:"Pid,omitempty"`
+	Restarting bool         `json:"Restarting,omitempty"`
+	Running    bool         `json:"Running,omitempty"`
+	StartedAt  string       `json:"StartedAt,omitempty"`
+	Status     string       `json:"Status,omitempty"`
+}
+
+// HealthState represents the health state of a container.
+type HealthState struct {
+	FailingStreak int         `json:"FailingStreak,omitempty"`
+	Log           []HealthLog `json:"Log,omitempty"`
+	Status        string      `json:"Status,omitempty"`
+}
+
+// HealthLog represents a health check log entry.
+type HealthLog struct {
+	End      string `json:"End,omitempty"`
+	ExitCode int    `json:"ExitCode,omitempty"`
+	Output   string `json:"Output,omitempty"`
+	Start    string `json:"Start,omitempty"`
+}
+
+// ImageListResponse represents an image in the list response.
+// Compatible with both Libpod and Docker APIs.
+type ImageListResponse struct {
+	Containers  int               `json:"Containers,omitempty"`
+	Created     int64             `json:"Created"`
+	Dangling    bool              `json:"Dangling,omitempty"`
+	Digest      string            `json:"Digest,omitempty"`
+	History     []string          `json:"History,omitempty"`
+	ID          string            `json:"Id"`
+	Labels      map[string]string `json:"Labels,omitempty"`
+	Names       []string          `json:"Names,omitempty"`
+	ParentId    string            `json:"ParentId,omitempty"`
+	ReadOnly    bool              `json:"ReadOnly,omitempty"`
+	RepoDigests []string          `json:"RepoDigests,omitempty"`
+	RepoTags    []string          `json:"RepoTags,omitempty"`
+	SharedSize  int64             `json:"SharedSize,omitempty"`
+	Size        int64             `json:"Size"`
+	VirtualSize int64             `json:"VirtualSize,omitempty"`
+}
+
+// NetworkListResponse represents a network in the list response.
+// Compatible with both Libpod and Docker APIs.
+type NetworkListResponse struct {
+	Attachable bool                   `json:"Attachable,omitempty"`
+	ConfigFrom *ConfigReference       `json:"ConfigFrom,omitempty"`
+	ConfigOnly bool                   `json:"ConfigOnly,omitempty"`
+	Containers map[string]interface{} `json:"Containers,omitempty"`
+	Created    string                 `json:"Created,omitempty"`
+	Driver     string                 `json:"Driver,omitempty"`
+	EnableIPv6 bool                   `json:"EnableIPv6,omitempty"`
+	ID         string                 `json:"Id,omitempty"`
+	IPAM       *IPAM                  `json:"IPAM,omitempty"`
+	Ingress    bool                   `json:"Ingress,omitempty"`
+	Internal   bool                   `json:"Internal,omitempty"`
+	Labels     map[string]string      `json:"Labels,omitempty"`
+	Name       string                 `json:"Name"`
+	Options    map[string]string      `json:"Options,omitempty"`
+	Scope      string                 `json:"Scope,omitempty"`
+	// Libpod-specific fields
+	DNSEnabled       bool     `json:"dns_enabled,omitempty"`
+	IPV6Enabled      bool     `json:"ipv6_enabled,omitempty"`
+	NetworkInterface string   `json:"network_interface,omitempty"`
+	Subnets          []Subnet `json:"subnets,omitempty"`
+}
+
+// ConfigReference represents a network config reference.
+type ConfigReference struct {
+	Network string `json:"Network,omitempty"`
+}
+
+// IPAM represents IP Address Management configuration.
+type IPAM struct {
+	Config  []IPAMPoolConfig  `json:"Config,omitempty"`
+	Driver  string            `json:"Driver,omitempty"`
+	Options map[string]string `json:"Options,omitempty"`
+}
+
+// IPAMPoolConfig represents an IPAM pool configuration.
+type IPAMPoolConfig struct {
+	AuxiliaryAddresses map[string]string `json:"AuxiliaryAddresses,omitempty"`
+	Gateway            string            `json:"Gateway,omitempty"`
+	IPRange            string            `json:"IPRange,omitempty"`
+	Subnet             string            `json:"Subnet,omitempty"`
+}
+
+// Subnet represents a network subnet.
+type Subnet struct {
+	Gateway string `json:"gateway,omitempty"`
+	Subnet  string `json:"subnet,omitempty"`
+}
+
+// VolumeListResponse represents the volume list response.
+type VolumeListResponse struct {
+	Volumes  []VolumeResponse `json:"Volumes,omitempty"`
+	Warnings []string         `json:"Warnings,omitempty"`
+}
+
+// VolumeResponse represents a volume in the list response.
+// Compatible with both Libpod and Docker APIs.
+type VolumeResponse struct {
+	CreatedAt  string                 `json:"CreatedAt,omitempty"`
+	Driver     string                 `json:"Driver"`
+	Labels     map[string]string      `json:"Labels,omitempty"`
+	Mountpoint string                 `json:"Mountpoint"`
+	Name       string                 `json:"Name"`
+	Options    map[string]string      `json:"Options,omitempty"`
+	Scope      string                 `json:"Scope,omitempty"`
+	Status     map[string]interface{} `json:"Status,omitempty"`
+	UsageData  *VolumeUsageData       `json:"UsageData,omitempty"`
+	// Libpod-specific fields
+	Anonymous   bool `json:"Anonymous,omitempty"`
+	GID         int  `json:"GID,omitempty"`
+	UID         int  `json:"UID,omitempty"`
+	NeedsChown  bool `json:"NeedsChown,omitempty"`
+	NeedsCopyUp bool `json:"NeedsCopyUp,omitempty"`
+}
+
+// VolumeUsageData represents volume usage data.
+type VolumeUsageData struct {
+	RefCount int64 `json:"RefCount,omitempty"`
+	Size     int64 `json:"Size,omitempty"`
+}
+
+// ContainerCreateRequest represents a container creation request.
+type ContainerCreateRequest struct {
+	Name       string            `json:"name,omitempty"`
+	Image      string            `json:"image"`
+	Cmd        []string          `json:"command,omitempty"`
+	Env        []string          `json:"env,omitempty"`
+	Labels     map[string]string `json:"labels,omitempty"`
+	HostConfig *HostConfig       `json:"HostConfig,omitempty"`
+}
+
+// ContainerCreateResponse represents a container creation response.
+type ContainerCreateResponse struct {
+	ID       string   `json:"Id"`
+	Warnings []string `json:"Warnings,omitempty"`
+}
+
+// ImagePullResponse represents an image pull progress response.
+type ImagePullResponse struct {
+	Error          string          `json:"error,omitempty"`
+	ErrorDetail    *ErrorDetail    `json:"errorDetail,omitempty"`
+	ID             string          `json:"id,omitempty"`
+	Images         []string        `json:"images,omitempty"`
+	Progress       string          `json:"progress,omitempty"`
+	ProgressDetail *ProgressDetail `json:"progressDetail,omitempty"`
+	Status         string          `json:"status,omitempty"`
+	Stream         string          `json:"stream,omitempty"`
+}
+
+// ErrorDetail represents error details in a response.
+type ErrorDetail struct {
+	Code    int    `json:"code,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+// ProgressDetail represents progress details.
+type ProgressDetail struct {
+	Current int64 `json:"current,omitempty"`
+	Total   int64 `json:"total,omitempty"`
+}
+
+// ImageBuildResponse represents an image build progress response.
+type ImageBuildResponse struct {
+	Aux         *BuildAux    `json:"aux,omitempty"`
+	Error       string       `json:"error,omitempty"`
+	ErrorDetail *ErrorDetail `json:"errorDetail,omitempty"`
+	ID          string       `json:"id,omitempty"`
+	Progress    string       `json:"progress,omitempty"`
+	Status      string       `json:"status,omitempty"`
+	Stream      string       `json:"stream,omitempty"`
+}
+
+// BuildAux represents auxiliary build information.
+type BuildAux struct {
+	ID string `json:"ID,omitempty"`
+}
+
+// ImageRemoveResponse represents the response from removing an image.
+type ImageRemoveResponse struct {
+	Deleted  string `json:"Deleted,omitempty"`
+	Untagged string `json:"Untagged,omitempty"`
+}


### PR DESCRIPTION
Add mock HTTP server that simulates Podman/Docker REST API for testing. This enables tests to use the real podman/docker CLI binary communicating with a mocked backend instead of a fake binary.

Key components:
- MockPodmanServer: HTTP server with handler registration and request capture
- Dual API support: Both Libpod (/libpod/...) and Docker-compatible paths
- Base endpoints: /_ping, /version, /info with versioned Docker API support
- MockServerMcpSuite: Test suite that configures CONTAINER_HOST/DOCKER_HOST
- Shared response types compatible with both APIs

Part of #76