### PR TITLE
chore(docs): finalize REST API bindings documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,30 @@ podman-mcp-server --port 8080
 podman-mcp-server --sse-port 8080
 ```
 
+### Podman Implementations
+
+The server supports multiple Podman backend implementations:
+
+| Implementation | Description | Priority |
+|----------------|-------------|----------|
+| `api` | Podman REST API via Unix socket | 100 (preferred) |
+| `cli` | Podman/Docker CLI wrapper | 50 (fallback) |
+
+By default, the server **auto-detects** the best available implementation.
+The `api` implementation is preferred when a Podman socket is available, otherwise the `cli` implementation is used as a fallback.
+
+Use the `--podman-impl` flag to force a specific implementation:
+
+```shell
+# Force CLI implementation
+podman-mcp-server --podman-impl=cli
+
+# Force API implementation (requires Podman socket)
+podman-mcp-server --podman-impl=api
+```
+
+The `api` implementation communicates directly with the Podman REST API via Unix socket, while the `cli` implementation shells out to the `podman` or `docker` binary.
+
 ## 🛠️ Tools <a id="tools"></a>
 
 <!-- AVAILABLE-TOOLS-START -->

--- a/docs/specs/podman-interface.md
+++ b/docs/specs/podman-interface.md
@@ -6,7 +6,7 @@ The `Podman` interface abstracts container runtime operations, allowing multiple
 
 ## Status
 
-**Partially implemented.** The registry pattern and CLI implementation are complete (Phase 1). The `api` implementation will be added as part of [Podman REST API Bindings](./podman-rest-api-bindings.md) Phase 2.
+**Implemented.** The registry pattern, CLI implementation, and API implementation are complete. See [Podman REST API Bindings](./podman-rest-api-bindings.md) for the API implementation details.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
- Updated spec statuses from "Planned"/"Partially implemented"/"Not yet implemented" to **Implemented** in both specs and AGENTS.md
- Added **Podman Implementations** section to README.md documenting `api` and `cli` backends, auto-detection, and `--podman-impl` flag usage
- Expanded AGENTS.md Podman Interface section with registry pattern, both implementations, and socket detection details
- Added `github.com/containers/podman/v5` to key dependencies in AGENTS.md
- Removed the ephemeral Implementation Plan section from `docs/specs/podman-rest-api-bindings.md`

Closes #89

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Verify spec documents are accurate against current implementation
- [ ] Verify AGENTS.md changes are consistent with codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)