### PR TITLE
refactor(mcp): migrate tools to self-registering toolsets

### DIFF
--- a/pkg/api/helpers.go
+++ b/pkg/api/helpers.go
@@ -1,0 +1,7 @@
+package api
+
+// Ptr returns a pointer to the given value. Useful for setting optional
+// pointer fields such as the *bool tool annotation hints.
+func Ptr[T any](v T) *T {
+	return &v
+}

--- a/pkg/api/toolsets.go
+++ b/pkg/api/toolsets.go
@@ -1,0 +1,7 @@
+package api
+
+type Toolset interface {
+	GetName() string
+	GetDescription() string
+	GetTools() []ServerTool
+}

--- a/pkg/mcp/gosdk.go
+++ b/pkg/mcp/gosdk.go
@@ -130,8 +130,3 @@ func derefBool(ptr *bool, defaultVal bool) bool {
 	}
 	return *ptr
 }
-
-// ptr returns a pointer to the given value.
-func ptr[T any](v T) *T {
-	return &v
-}

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"slices"
 
 	"github.com/manusa/podman-mcp-server/pkg/api"
 	"github.com/manusa/podman-mcp-server/pkg/config"
 	"github.com/manusa/podman-mcp-server/pkg/podman"
+	"github.com/manusa/podman-mcp-server/pkg/toolsets"
 	"github.com/manusa/podman-mcp-server/pkg/version"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -67,12 +67,11 @@ func (s *Server) ServeSse() *mcp.SSEHandler {
 
 // AllTools returns all registered tools for documentation purposes.
 func AllTools() []api.ServerTool {
-	return slices.Concat(
-		initContainerTools(),
-		initImageTools(),
-		initNetworkTools(),
-		initVolumeTools(),
-	)
+	var all []api.ServerTool
+	for _, ts := range toolsets.Toolsets() {
+		all = append(all, ts.GetTools()...)
+	}
+	return all
 }
 
 // ServeStreamableHTTP returns an HTTP handler for Streamable HTTP transport.

--- a/pkg/mcp/modules.go
+++ b/pkg/mcp/modules.go
@@ -1,0 +1,9 @@
+package mcp
+
+import (
+	// Blank imports trigger each toolset's init() self-registration.
+	_ "github.com/manusa/podman-mcp-server/pkg/toolsets/container"
+	_ "github.com/manusa/podman-mcp-server/pkg/toolsets/image"
+	_ "github.com/manusa/podman-mcp-server/pkg/toolsets/network"
+	_ "github.com/manusa/podman-mcp-server/pkg/toolsets/volume"
+)

--- a/pkg/toolsets/container/container.go
+++ b/pkg/toolsets/container/container.go
@@ -1,12 +1,18 @@
-package mcp
+package container
 
 import (
 	"context"
 
 	"github.com/manusa/podman-mcp-server/pkg/api"
+	"github.com/manusa/podman-mcp-server/pkg/toolsets"
 )
 
-func initContainerTools() []api.ServerTool {
+type toolset struct{}
+
+func (t toolset) GetName() string        { return "container" }
+func (t toolset) GetDescription() string { return "Container management tools" }
+
+func (t toolset) GetTools() []api.ServerTool {
 	return []api.ServerTool{
 		{
 			Tool: api.Tool{
@@ -14,10 +20,10 @@ func initContainerTools() []api.ServerTool {
 				Description: "Displays the low-level information and configuration of a Docker or Podman container with the specified container ID or name",
 				Annotations: api.ToolAnnotations{
 					Title:           "Container: Inspect",
-					ReadOnlyHint:    ptr(true),
-					DestructiveHint: ptr(false),
-					IdempotentHint:  ptr(true),
-					OpenWorldHint:   ptr(false),
+					ReadOnlyHint:    api.Ptr(true),
+					DestructiveHint: api.Ptr(false),
+					IdempotentHint:  api.Ptr(true),
+					OpenWorldHint:   api.Ptr(false),
 				},
 				InputSchema: api.InputSchema{
 					Type: "object",
@@ -38,10 +44,10 @@ func initContainerTools() []api.ServerTool {
 				Description: "Prints out information about the running Docker or Podman containers",
 				Annotations: api.ToolAnnotations{
 					Title:           "Container: List",
-					ReadOnlyHint:    ptr(true),
-					DestructiveHint: ptr(false),
-					IdempotentHint:  ptr(true),
-					OpenWorldHint:   ptr(false),
+					ReadOnlyHint:    api.Ptr(true),
+					DestructiveHint: api.Ptr(false),
+					IdempotentHint:  api.Ptr(true),
+					OpenWorldHint:   api.Ptr(false),
 				},
 				InputSchema: api.InputSchema{
 					Type: "object",
@@ -55,10 +61,10 @@ func initContainerTools() []api.ServerTool {
 				Description: "Displays the logs of a Docker or Podman container with the specified container ID or name",
 				Annotations: api.ToolAnnotations{
 					Title:           "Container: Logs",
-					ReadOnlyHint:    ptr(true),
-					DestructiveHint: ptr(false),
-					IdempotentHint:  ptr(true),
-					OpenWorldHint:   ptr(false),
+					ReadOnlyHint:    api.Ptr(true),
+					DestructiveHint: api.Ptr(false),
+					IdempotentHint:  api.Ptr(true),
+					OpenWorldHint:   api.Ptr(false),
 				},
 				InputSchema: api.InputSchema{
 					Type: "object",
@@ -79,10 +85,10 @@ func initContainerTools() []api.ServerTool {
 				Description: "Removes a Docker or Podman container with the specified container ID or name (rm)",
 				Annotations: api.ToolAnnotations{
 					Title:           "Container: Remove",
-					ReadOnlyHint:    ptr(false),
-					DestructiveHint: ptr(true),
-					IdempotentHint:  ptr(false),
-					OpenWorldHint:   ptr(false),
+					ReadOnlyHint:    api.Ptr(false),
+					DestructiveHint: api.Ptr(true),
+					IdempotentHint:  api.Ptr(false),
+					OpenWorldHint:   api.Ptr(false),
 				},
 				InputSchema: api.InputSchema{
 					Type: "object",
@@ -103,10 +109,10 @@ func initContainerTools() []api.ServerTool {
 				Description: "Runs a Docker or Podman container with the specified image name",
 				Annotations: api.ToolAnnotations{
 					Title:           "Container: Run",
-					ReadOnlyHint:    ptr(false),
-					DestructiveHint: ptr(false),
-					IdempotentHint:  ptr(false),
-					OpenWorldHint:   ptr(false),
+					ReadOnlyHint:    api.Ptr(false),
+					DestructiveHint: api.Ptr(false),
+					IdempotentHint:  api.Ptr(false),
+					OpenWorldHint:   api.Ptr(false),
 				},
 				InputSchema: api.InputSchema{
 					Type: "object",
@@ -141,10 +147,10 @@ func initContainerTools() []api.ServerTool {
 				Description: "Stops a Docker or Podman running container with the specified container ID or name",
 				Annotations: api.ToolAnnotations{
 					Title:           "Container: Stop",
-					ReadOnlyHint:    ptr(false),
-					DestructiveHint: ptr(false),
-					IdempotentHint:  ptr(true),
-					OpenWorldHint:   ptr(false),
+					ReadOnlyHint:    api.Ptr(false),
+					DestructiveHint: api.Ptr(false),
+					IdempotentHint:  api.Ptr(true),
+					OpenWorldHint:   api.Ptr(false),
 				},
 				InputSchema: api.InputSchema{
 					Type: "object",
@@ -160,6 +166,10 @@ func initContainerTools() []api.ServerTool {
 			Handler: containerStop,
 		},
 	}
+}
+
+func init() {
+	toolsets.Register(toolset{})
 }
 
 func containerInspect(_ context.Context, params api.ToolHandlerParams) (*api.ToolCallResult, error) {

--- a/pkg/toolsets/image/image.go
+++ b/pkg/toolsets/image/image.go
@@ -1,12 +1,18 @@
-package mcp
+package image
 
 import (
 	"context"
 
 	"github.com/manusa/podman-mcp-server/pkg/api"
+	"github.com/manusa/podman-mcp-server/pkg/toolsets"
 )
 
-func initImageTools() []api.ServerTool {
+type toolset struct{}
+
+func (t toolset) GetName() string        { return "image" }
+func (t toolset) GetDescription() string { return "Image management tools" }
+
+func (t toolset) GetTools() []api.ServerTool {
 	return []api.ServerTool{
 		{
 			Tool: api.Tool{
@@ -14,10 +20,10 @@ func initImageTools() []api.ServerTool {
 				Description: "Build a Docker or Podman image from a Dockerfile, Podmanfile, or Containerfile",
 				Annotations: api.ToolAnnotations{
 					Title:           "Image: Build",
-					ReadOnlyHint:    ptr(false),
-					DestructiveHint: ptr(false),
-					IdempotentHint:  ptr(false),
-					OpenWorldHint:   ptr(false),
+					ReadOnlyHint:    api.Ptr(false),
+					DestructiveHint: api.Ptr(false),
+					IdempotentHint:  api.Ptr(false),
+					OpenWorldHint:   api.Ptr(false),
 				},
 				InputSchema: api.InputSchema{
 					Type: "object",
@@ -42,10 +48,10 @@ func initImageTools() []api.ServerTool {
 				Description: "List the Docker or Podman images on the local machine",
 				Annotations: api.ToolAnnotations{
 					Title:           "Image: List",
-					ReadOnlyHint:    ptr(true),
-					DestructiveHint: ptr(false),
-					IdempotentHint:  ptr(true),
-					OpenWorldHint:   ptr(false),
+					ReadOnlyHint:    api.Ptr(true),
+					DestructiveHint: api.Ptr(false),
+					IdempotentHint:  api.Ptr(true),
+					OpenWorldHint:   api.Ptr(false),
 				},
 				InputSchema: api.InputSchema{
 					Type: "object",
@@ -59,10 +65,10 @@ func initImageTools() []api.ServerTool {
 				Description: "Copies (pulls) a Docker or Podman container image from a registry onto the local machine storage",
 				Annotations: api.ToolAnnotations{
 					Title:           "Image: Pull",
-					ReadOnlyHint:    ptr(false),
-					DestructiveHint: ptr(false),
-					IdempotentHint:  ptr(true),
-					OpenWorldHint:   ptr(true),
+					ReadOnlyHint:    api.Ptr(false),
+					DestructiveHint: api.Ptr(false),
+					IdempotentHint:  api.Ptr(true),
+					OpenWorldHint:   api.Ptr(true),
 				},
 				InputSchema: api.InputSchema{
 					Type: "object",
@@ -83,10 +89,10 @@ func initImageTools() []api.ServerTool {
 				Description: "Pushes a Docker or Podman container image, manifest list or image index from local machine storage to a registry",
 				Annotations: api.ToolAnnotations{
 					Title:           "Image: Push",
-					ReadOnlyHint:    ptr(false),
-					DestructiveHint: ptr(false),
-					IdempotentHint:  ptr(true),
-					OpenWorldHint:   ptr(true),
+					ReadOnlyHint:    api.Ptr(false),
+					DestructiveHint: api.Ptr(false),
+					IdempotentHint:  api.Ptr(true),
+					OpenWorldHint:   api.Ptr(true),
 				},
 				InputSchema: api.InputSchema{
 					Type: "object",
@@ -107,10 +113,10 @@ func initImageTools() []api.ServerTool {
 				Description: "Removes a Docker or Podman image from the local machine storage",
 				Annotations: api.ToolAnnotations{
 					Title:           "Image: Remove",
-					ReadOnlyHint:    ptr(false),
-					DestructiveHint: ptr(true),
-					IdempotentHint:  ptr(false),
-					OpenWorldHint:   ptr(false),
+					ReadOnlyHint:    api.Ptr(false),
+					DestructiveHint: api.Ptr(true),
+					IdempotentHint:  api.Ptr(false),
+					OpenWorldHint:   api.Ptr(false),
 				},
 				InputSchema: api.InputSchema{
 					Type: "object",
@@ -126,6 +132,10 @@ func initImageTools() []api.ServerTool {
 			Handler: imageRemove,
 		},
 	}
+}
+
+func init() {
+	toolsets.Register(toolset{})
 }
 
 func imageBuild(_ context.Context, params api.ToolHandlerParams) (*api.ToolCallResult, error) {

--- a/pkg/toolsets/network/network.go
+++ b/pkg/toolsets/network/network.go
@@ -1,12 +1,18 @@
-package mcp
+package network
 
 import (
 	"context"
 
 	"github.com/manusa/podman-mcp-server/pkg/api"
+	"github.com/manusa/podman-mcp-server/pkg/toolsets"
 )
 
-func initNetworkTools() []api.ServerTool {
+type toolset struct{}
+
+func (t toolset) GetName() string        { return "network" }
+func (t toolset) GetDescription() string { return "Network management tools" }
+
+func (t toolset) GetTools() []api.ServerTool {
 	return []api.ServerTool{
 		{
 			Tool: api.Tool{
@@ -14,10 +20,10 @@ func initNetworkTools() []api.ServerTool {
 				Description: "List all the available Docker or Podman networks",
 				Annotations: api.ToolAnnotations{
 					Title:           "Network: List",
-					ReadOnlyHint:    ptr(true),
-					DestructiveHint: ptr(false),
-					IdempotentHint:  ptr(true),
-					OpenWorldHint:   ptr(false),
+					ReadOnlyHint:    api.Ptr(true),
+					DestructiveHint: api.Ptr(false),
+					IdempotentHint:  api.Ptr(true),
+					OpenWorldHint:   api.Ptr(false),
 				},
 				InputSchema: api.InputSchema{
 					Type: "object",
@@ -26,6 +32,10 @@ func initNetworkTools() []api.ServerTool {
 			Handler: networkList,
 		},
 	}
+}
+
+func init() {
+	toolsets.Register(toolset{})
 }
 
 func networkList(_ context.Context, params api.ToolHandlerParams) (*api.ToolCallResult, error) {

--- a/pkg/toolsets/toolsets.go
+++ b/pkg/toolsets/toolsets.go
@@ -1,0 +1,38 @@
+package toolsets
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/manusa/podman-mcp-server/pkg/api"
+)
+
+var registry = make(map[string]api.Toolset)
+
+// Register adds a toolset to the global registry. Panics on duplicate name,
+// which is a programming error surfaced at init() time.
+func Register(toolset api.Toolset) {
+	name := toolset.GetName()
+	if _, exists := registry[name]; exists {
+		panic(fmt.Sprintf("toolset already registered for name: %s", name))
+	}
+	registry[name] = toolset
+}
+
+// Toolsets returns all registered toolsets sorted by name for deterministic order.
+func Toolsets() []api.Toolset {
+	result := make([]api.Toolset, 0, len(registry))
+	for _, ts := range registry {
+		result = append(result, ts)
+	}
+	slices.SortFunc(result, func(a, b api.Toolset) int {
+		return strings.Compare(a.GetName(), b.GetName())
+	})
+	return result
+}
+
+// ToolsetFromString returns the toolset with the given name, or nil if none.
+func ToolsetFromString(name string) api.Toolset {
+	return registry[strings.TrimSpace(name)]
+}

--- a/pkg/toolsets/toolsets_test.go
+++ b/pkg/toolsets/toolsets_test.go
@@ -1,0 +1,34 @@
+package toolsets_test
+
+import (
+	"testing"
+
+	"github.com/manusa/podman-mcp-server/pkg/api"
+	"github.com/manusa/podman-mcp-server/pkg/toolsets"
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeToolset struct{ name string }
+
+func (f fakeToolset) GetName() string            { return f.name }
+func (f fakeToolset) GetDescription() string     { return "fake" }
+func (f fakeToolset) GetTools() []api.ServerTool { return nil }
+
+func TestRegisterAndRetrieve(t *testing.T) {
+	toolsets.Register(fakeToolset{name: "a-test"})
+	toolsets.Register(fakeToolset{name: "b-test"})
+
+	t.Run("ToolsetFromString finds registered", func(t *testing.T) {
+		assert.NotNil(t, toolsets.ToolsetFromString("a-test"))
+		assert.NotNil(t, toolsets.ToolsetFromString("b-test"))
+	})
+
+	t.Run("ToolsetFromString returns nil for unknown", func(t *testing.T) {
+		assert.Nil(t, toolsets.ToolsetFromString("c-test"))
+	})
+
+	t.Run("Toolsets returns sorted by name", func(t *testing.T) {
+		all := toolsets.Toolsets()
+		assert.Equal(t, "a-test", all[0].GetName())
+	})
+}

--- a/pkg/toolsets/volume/volume.go
+++ b/pkg/toolsets/volume/volume.go
@@ -1,12 +1,18 @@
-package mcp
+package volume
 
 import (
 	"context"
 
 	"github.com/manusa/podman-mcp-server/pkg/api"
+	"github.com/manusa/podman-mcp-server/pkg/toolsets"
 )
 
-func initVolumeTools() []api.ServerTool {
+type toolset struct{}
+
+func (t toolset) GetName() string        { return "volume" }
+func (t toolset) GetDescription() string { return "Volume management tools" }
+
+func (t toolset) GetTools() []api.ServerTool {
 	return []api.ServerTool{
 		{
 			Tool: api.Tool{
@@ -14,10 +20,10 @@ func initVolumeTools() []api.ServerTool {
 				Description: "List all the available Docker or Podman volumes",
 				Annotations: api.ToolAnnotations{
 					Title:           "Volume: List",
-					ReadOnlyHint:    ptr(true),
-					DestructiveHint: ptr(false),
-					IdempotentHint:  ptr(true),
-					OpenWorldHint:   ptr(false),
+					ReadOnlyHint:    api.Ptr(true),
+					DestructiveHint: api.Ptr(false),
+					IdempotentHint:  api.Ptr(true),
+					OpenWorldHint:   api.Ptr(false),
 				},
 				InputSchema: api.InputSchema{
 					Type: "object",
@@ -26,6 +32,10 @@ func initVolumeTools() []api.ServerTool {
 			Handler: volumeList,
 		},
 	}
+}
+
+func init() {
+	toolsets.Register(toolset{})
 }
 
 func volumeList(_ context.Context, params api.ToolHandlerParams) (*api.ToolCallResult, error) {


### PR DESCRIPTION
## Summary

Closes #63

Restructures the MCP tool layer to adopt the toolset-based modular architecture from kubernetes-mcp-server:
   
- Introduces `pkg/api.Toolset` interface as the shared contract for tool groupings
- Adds `pkg/toolsets` registry — a global map with `Register()`, `Toolsets()`, and `ToolsetFromString()` helpers; panics on duplicate registration to surface wiring bugs at init time
- Moves each resource's tools into a self-contained package(`pkg/toolsets/container`, `image`, `network`, `volume`) that self-registers via `init()`
- Adds `pkg/mcp/modules.go` with blank imports to wire all toolsets into the server without manual registration calls in `mcp.go`

## Issue Checklist (#63)

### Scope
- [x] Create `pkg/api/` package with interface definitions (`ServerTool`, `Tool`, `ToolHandlerFunc`, `ToolHandlerParams`)
- [x] Create `pkg/toolsets/` directory with modular tool organization
- [x] Refactor existing tools into toolsets: `container`, `image`, `network`, `volume`
- [x] Implement toolset registration pattern with auto-loading via init imports
- [x] Create `pkg/mcp/modules.go` for toolset imports
- [x] Update MCP server to use toolset-based tool registration

### Acceptance Criteria
- [x] `pkg/api/` contains all shared interfaces and types
- [x] Each resource type (container, image, network, volume) is a separate toolset
- [x] Toolsets are auto-registered via init imports
- [x] All existing tests pass
- [ ] Code follows the same patterns as kubernetes-mcp-server

The only unchecked acceptance criterion is "Code follows the same patterns as kubernetes-mcp-server" — worth leaving open since that's a subjective alignment check the reviewer may want to confirm.