### PR TITLE
  feat(output): add list tool output abstraction

### DIFF
--- a/pkg/api/tools.go
+++ b/pkg/api/tools.go
@@ -4,6 +4,7 @@ package api
 import (
 	"context"
 
+	"github.com/manusa/podman-mcp-server/pkg/output"
 	"github.com/manusa/podman-mcp-server/pkg/podman"
 )
 
@@ -20,6 +21,7 @@ type ToolHandlerFunc func(ctx context.Context, params ToolHandlerParams) (*ToolC
 type ToolHandlerParams struct {
 	Podman    podman.Podman
 	Arguments map[string]any
+	Output    output.Output
 }
 
 // Tool represents a tool definition.

--- a/pkg/mcp/gosdk.go
+++ b/pkg/mcp/gosdk.go
@@ -7,12 +7,13 @@ import (
 	"fmt"
 
 	"github.com/manusa/podman-mcp-server/pkg/api"
+	"github.com/manusa/podman-mcp-server/pkg/output"
 	"github.com/manusa/podman-mcp-server/pkg/podman"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 // ServerToolToGoSdkTool converts an internal ServerTool to go-sdk format.
-func ServerToolToGoSdkTool(p podman.Podman, tool api.ServerTool) (*mcp.Tool, mcp.ToolHandler, error) {
+func ServerToolToGoSdkTool(p podman.Podman, out output.Output, tool api.ServerTool) (*mcp.Tool, mcp.ToolHandler, error) {
 	goSdkTool := &mcp.Tool{
 		Name:        tool.Tool.Name,
 		Description: tool.Tool.Description,
@@ -29,6 +30,7 @@ func ServerToolToGoSdkTool(p podman.Podman, tool api.ServerTool) (*mcp.Tool, mcp
 		params := api.ToolHandlerParams{
 			Podman:    p,
 			Arguments: arguments,
+			Output:    out,
 		}
 
 		result, err := tool.Handler(ctx, params)

--- a/pkg/mcp/mcp.go
+++ b/pkg/mcp/mcp.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/manusa/podman-mcp-server/pkg/api"
 	"github.com/manusa/podman-mcp-server/pkg/config"
+	"github.com/manusa/podman-mcp-server/pkg/output"
 	"github.com/manusa/podman-mcp-server/pkg/podman"
 	"github.com/manusa/podman-mcp-server/pkg/version"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -41,9 +42,11 @@ func NewServer(cfg config.Config) (*Server, error) {
 		return nil, err
 	}
 
+	output := output.New(cfg.OutputFormat)
+
 	// Register all tools
 	for _, tool := range AllTools() {
-		goSdkTool, handler, err := ServerToolToGoSdkTool(s.podman, tool)
+		goSdkTool, handler, err := ServerToolToGoSdkTool(s.podman, output, tool)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert tool %s: %w", tool.Tool.Name, err)
 		}

--- a/pkg/mcp/podman_container.go
+++ b/pkg/mcp/podman_container.go
@@ -173,7 +173,11 @@ func containerInspect(_ context.Context, params api.ToolHandlerParams) (*api.Too
 
 func containerList(_ context.Context, params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	result, err := params.Podman.ContainerList()
-	return api.NewToolCallResult(result, err), nil
+	if err != nil {
+		return api.NewToolCallResult("", err), nil
+	}
+	formatted, err := params.Output.Format(result)
+	return api.NewToolCallResult(formatted, err), nil
 }
 
 func containerLogs(_ context.Context, params api.ToolHandlerParams) (*api.ToolCallResult, error) {

--- a/pkg/mcp/podman_image.go
+++ b/pkg/mcp/podman_image.go
@@ -140,7 +140,11 @@ func imageBuild(_ context.Context, params api.ToolHandlerParams) (*api.ToolCallR
 
 func imageList(_ context.Context, params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	result, err := params.Podman.ImageList()
-	return api.NewToolCallResult(result, err), nil
+	if err != nil {
+		return api.NewToolCallResult("", err), nil
+	}
+	formatted, err := params.Output.Format(result)
+	return api.NewToolCallResult(formatted, err), nil
 }
 
 func imagePull(_ context.Context, params api.ToolHandlerParams) (*api.ToolCallResult, error) {

--- a/pkg/mcp/podman_network.go
+++ b/pkg/mcp/podman_network.go
@@ -30,5 +30,9 @@ func initNetworkTools() []api.ServerTool {
 
 func networkList(_ context.Context, params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	result, err := params.Podman.NetworkList()
-	return api.NewToolCallResult(result, err), nil
+	if err != nil {
+		return api.NewToolCallResult("", err), nil
+	}
+	formatted, err := params.Output.Format(result)
+	return api.NewToolCallResult(formatted, err), nil
 }

--- a/pkg/mcp/podman_volume.go
+++ b/pkg/mcp/podman_volume.go
@@ -30,5 +30,9 @@ func initVolumeTools() []api.ServerTool {
 
 func volumeList(_ context.Context, params api.ToolHandlerParams) (*api.ToolCallResult, error) {
 	result, err := params.Podman.VolumeList()
-	return api.NewToolCallResult(result, err), nil
+	if err != nil {
+		return api.NewToolCallResult("", err), nil
+	}
+	formatted, err := params.Output.Format(result)
+	return api.NewToolCallResult(formatted, err), nil
 }

--- a/pkg/output/json.go
+++ b/pkg/output/json.go
@@ -1,0 +1,16 @@
+package output
+
+import "encoding/json"
+
+type JSONOutput struct{}
+
+func (j *JSONOutput) Format(data interface{}) (string, error) {
+	if s, ok := data.(string); ok {
+		return s, nil
+	}
+	bytes, err := json.Marshal(data)
+	if err != nil {
+		return "", err
+	}
+	return string(bytes), nil
+}

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -1,0 +1,14 @@
+package output
+
+type Output interface {
+	Format(data interface{}) (string, error)
+}
+
+func New(format string) Output {
+	switch format {
+	case "json":
+		return &JSONOutput{}
+	default:
+		return &TextOutput{}
+	}
+}

--- a/pkg/output/output_test.go
+++ b/pkg/output/output_test.go
@@ -1,0 +1,111 @@
+package output_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/manusa/podman-mcp-server/pkg/output"
+)
+
+type OutputSuite struct {
+	suite.Suite
+}
+
+func TestOutput(t *testing.T) {
+	suite.Run(t, new(OutputSuite))
+}
+
+func (s *OutputSuite) TestNewReturnsJSONOutputForJSONFormat() {
+	out := output.New("json")
+	s.IsType(&output.JSONOutput{}, out)
+}
+
+func (s *OutputSuite) TestNewReturnsTextOutputForTextFormat() {
+	out := output.New("text")
+	s.IsType(&output.TextOutput{}, out)
+}
+
+func (s *OutputSuite) TestNewReturnsTextOutputForUnknownFormat() {
+	out := output.New("yaml")
+	s.IsType(&output.TextOutput{}, out)
+}
+
+func (s *OutputSuite) TestNewReturnsTextOutputForEmptyFormat() {
+	out := output.New("")
+	s.IsType(&output.TextOutput{}, out)
+}
+
+func (s *OutputSuite) TestJSONOutputFormatPassesThroughString() {
+	out := &output.JSONOutput{}
+
+	result, err := out.Format("already a string")
+
+	s.Run("no error", func() {
+		s.NoError(err)
+	})
+	s.Run("returns string as-is", func() {
+		s.Equal("already a string", result)
+	})
+}
+
+func (s *OutputSuite) TestJSONOutputFormatMarshalsStruct() {
+	out := &output.JSONOutput{}
+
+	result, err := out.Format(map[string]string{"key": "value"})
+
+	s.Run("no error", func() {
+		s.NoError(err)
+	})
+	s.Run("returns valid JSON", func() {
+		s.JSONEq(`{"key":"value"}`, result)
+	})
+}
+
+func (s *OutputSuite) TestJSONOutputFormatMarshalsSlice() {
+	out := &output.JSONOutput{}
+
+	result, err := out.Format([]string{"a", "b"})
+
+	s.Run("no error", func() {
+		s.NoError(err)
+	})
+	s.Run("returns valid JSON array", func() {
+		s.JSONEq(`["a","b"]`, result)
+	})
+}
+
+func (s *OutputSuite) TestJSONOutputFormatReturnsErrorForUnmarshalableData() {
+	out := &output.JSONOutput{}
+
+	// channels cannot be marshaled to JSON
+	_, err := out.Format(make(chan int))
+
+	s.Error(err)
+}
+
+func (s *OutputSuite) TestTextOutputFormatPassesThroughString() {
+	out := &output.TextOutput{}
+
+	result, err := out.Format("plain text output")
+
+	s.Run("no error", func() {
+		s.NoError(err)
+	})
+	s.Run("returns string as-is", func() {
+		s.Equal("plain text output", result)
+	})
+}
+
+func (s *OutputSuite) TestTextOutputFormatConvertsNonString() {
+	out := &output.TextOutput{}
+
+	result, err := out.Format(42)
+
+	s.Run("no error", func() {
+		s.NoError(err)
+	})
+	s.Run("returns string representation", func() {
+		s.Equal("42", result)
+	})
+}

--- a/pkg/output/text.go
+++ b/pkg/output/text.go
@@ -1,0 +1,12 @@
+package output
+
+import "fmt"
+
+type TextOutput struct{}
+
+func (t *TextOutput) Format(data interface{}) (string, error) {
+	if s, ok := data.(string); ok {
+		return s, nil
+	}
+	return fmt.Sprintf("%v", data), nil
+}


### PR DESCRIPTION
  ## Dependency

  Depends on #63.

  This PR is based on `main` while the modular toolset architecture is still
  under review. It will be rebased onto the updated `main` after #63 merges.

  The branches currently merge cleanly, and the output formatting changes are
  preserved when the tool handlers move into `pkg/toolsets`.

  ## Summary

  Partially implements #73.

  Introduces the foundation for configurable tool output formatting:

  - Adds `pkg/output` with a shared `Output` interface and formatter factory
  - Implements `JSONOutput` for JSON serialization
  - Implements `TextOutput` to preserve existing human-readable output
  - Adds the selected output formatter to `api.ToolHandlerParams`
  - Wires the existing global `output-format` configuration into the abstraction
  - Updates the container, image, network, and volume list tools to use the
  configured formatter
  - Adds unit tests for formatter selection, JSON serialization, text
  formatting, and error handling

  ## Issue Checklist (#73)

  ### Scope

  - [x] Create `pkg/output/` package
  - [x] Implement JSON output formatter
  - [ ] Implement Table output formatter (kubectl-style)
  - [ ] Implement YAML output formatter
  - [ ] Add output configuration for all planned formats
  - [x] Update applicable list tools to use the output abstraction
  - [ ] Add per-tool `format` parameter to applicable tools

  The existing global `text`/`json` configuration is reused by this PR.
  Support for selecting `table` and `yaml` remains future work.

  ### Acceptance Criteria

  - [x] `pkg/output/` contains the formatter interface
  - [x] JSON formatter implementation is available
  - [ ] Table formatter implementation is available
  - [ ] YAML formatter implementation is available
  - [x] Container, image, network, and volume list tools use the output
  abstraction
  - [ ] Default format supports JSON, table, and YAML
  - [ ] Per-tool format override is supported
  - [x] All existing tests pass

  ## Testing

  ```text
  make test

  The complete test suite passes for:

  - The current feat/output-abstraction branch
  - An isolated merge with refactor/toolset-architecture

  ## Follow-up Work

  - Implement dedicated table and YAML formatters
  - Extend configuration and CLI validation with the remaining formats
  - Add per-tool format overrides
  - Move formatting responsibility fully out of the Podman implementations
  - Add MCP-level tests for table, YAML, and per-tool overrides


