### PR TITLE
chore(ci): install podman from release binary on macOS

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,7 +47,22 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
       - name: Install Podman (macOS)
         if: runner.os == 'macOS'
-        run: brew install podman
+        # Homebrew no longer publishes a podman bottle for the tier-3 Intel
+        # (x86_64) runner, so `brew install podman` fails there with
+        # "no bottle available". Install podman's official macOS release binary
+        # instead; it works on both amd64 and arm64 and is independent of
+        # Homebrew. Only the podman CLI is needed (tests run against a mock API
+        # server, so no podman machine is started).
+        env:
+          PODMAN_VERSION: v5.8.5
+        run: |
+          arch=amd64
+          if [ "$(uname -m)" = "arm64" ]; then arch=arm64; fi
+          url="https://github.com/containers/podman/releases/download/${PODMAN_VERSION}/podman-remote-release-darwin_${arch}.zip"
+          curl -fsSL -o "${RUNNER_TEMP}/podman.zip" "${url}"
+          unzip -q "${RUNNER_TEMP}/podman.zip" -d "${RUNNER_TEMP}/podman"
+          sudo install -m 0755 "${RUNNER_TEMP}"/podman/podman-*/usr/bin/podman /usr/local/bin/podman
+          podman --version
       - name: Install Podman (Windows)
         if: runner.os == 'Windows'
         run: choco install podman-cli -y


### PR DESCRIPTION
## Problem

The `Build on macos-15-intel` job started failing on every PR at the **Install Podman** step:

```
brew install podman
==> Fetching downloads for: podman
Error: podman: no bottle available!
```

Homebrew has stopped publishing a `podman` bottle for the **tier-3 Intel (x86_64)** macOS runner. This is infrastructure churn unrelated to any code change — the last green `macos-15-intel` run was 2026-06-27, and it has failed on all PRs since. It currently blocks the open Dependabot PRs (e.g. #119).

## Fix

Install podman from its **official macOS release binary** instead of Homebrew:

- Arch-detected — `podman-remote-release-darwin_amd64.zip` on Intel, `darwin_arm64` on Apple Silicon.
- Independent of Homebrew, so it is immune to bottle availability on **both** mac architectures.
- Only the podman CLI is needed: the suite runs the real CLI against a mock API server, and the podman-dependent tests skip when no `podman machine` is running (unchanged behavior — this is already what happens on `macos-latest`).

No change to the Linux or Windows jobs.

## Verification

- Both release-asset URLs return HTTP 200 (`darwin_amd64` and `darwin_arm64`).
- `macos-latest` behavior is unchanged (tests already skip there without a running machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
